### PR TITLE
Improved the contrast for try demo button

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,8 +195,7 @@
                                                                                   <tr class="wsite-multicol-tr">
                                                                                     <td class="wsite-multicol-col" style="width:50.866336633663%; padding:0 25px;">
                                                                                       <div class="wsite-spacer desktop-nav" style="height:91px;"></div>
-                                                                                      <h2 class="wsite-content-title text-shadow" style="text-align:left;">COMPANY CULTURE<br />TAKEN TO THE<br />NEXT LEVEL</h2>
-                                                                                      <!-- <h2 class="wsite-content-title text-shadow" style="text-align:left;"><font size="6">COMPANY CULTURE</font><br />&#8203;<font size="4">TAKEN TO THE</font><br /><font size="6">NEXT LEVEL</font></h2> -->
+                                                                                      <h2 class="wsite-content-title text-shadow" style="text-align:center;">COMPANY CULTURE<br />TAKEN TO THE<br />NEXT LEVEL</h2>
                                                                                       <div class="wsite-spacer desktop-nav" style="height:43px;"></div>
                                                                                       <div>
                                                                                         <div class="wsite-multicol">
@@ -204,20 +203,11 @@
                                                                                             <table class="wsite-multicol-table">
                                                                                               <tbody class="wsite-multicol-tbody">
                                                                                                 <tr class="wsite-multicol-tr">
-                                                                                                  <td class="wsite-multicol-col" style="width:42.241379310345%; padding:0 25px;">
-                                                                                                    <div style="text-align:left;">
+                                                                                                  <td class="wsite-multicol-col" style="width:57.758620689655%; padding:0 15px;">
+                                                                                                    <div style="text-align:center;">
                                                                                                       <div style="height: 10px; overflow: hidden;"></div>
-                                                                                                      <a class="wsite-button wsite-button-large wsite-button-highlight officeroo-button" href="#howitworks" >
-                                                                                                        <span class="wsite-button-inner">FIND OUT MORE</span>
-                                                                                                      </a>
-                                                                                                      <div style="height: 10px; overflow: hidden;"></div>
-                                                                                                    </div>
-                                                                                                  </td>
-                                                                                                  <td class="wsite-multicol-col" style="width:57.758620689655%; padding:0 25px;">
-                                                                                                    <div style="text-align:left;">
-                                                                                                      <div style="height: 10px; overflow: hidden;"></div>
-                                                                                                      <a class="wsite-button wsite-button-large wsite-button-highlight officeroo-button"  href="" data-toggle="modal" data-target="#DemoRequestModal" >
-                                                                                                        <span class="wsite-button-inner">REQUEST A DEMO</span>
+                                                                                                      <a class="wsite-button wsite-button-large wsite-button-highlight wsite-buy-button officeroo-button"  href="" data-toggle="modal" data-target="#DemoRequestModal" >
+                                                                                                        <span class="wsite-button-inner">TRY IT NOW!</span>
                                                                                                       </a>
                                                                                                       <div style="height: 10px; overflow: hidden;"></div>
                                                                                                     </div>


### PR DESCRIPTION
Changes, based on the UI talk from Startup School.

Rationale:
- There should only be one button. Users get confused if given 2 options. It should be clear what they should do next. In this case, that is to click the REQUEST a demo button. 
- The button should be contrasted, so it is obvious that we want users to click it
- The alignment is just a nitpick, it looked dirty before. I am fine with putting it slightly more to the left, but I think it should be center aligned.

Before / After
![screenshot778](https://user-images.githubusercontent.com/3248682/46571059-318d6f80-c966-11e8-82fb-40477458ba40.png)
![screenshot779](https://user-images.githubusercontent.com/3248682/46571060-318d6f80-c966-11e8-927f-ad33c10f1084.png)
